### PR TITLE
Mixed features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ tensorflow==2.15.0.post1
 # Optional requirements:
 # fastparquet  # alternative parquet engine
 # gcsfs # Reading files from Google Cloud
+
+# Model visualization dependencies
+# graphviz
+# pydot

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -327,16 +327,6 @@ def _get_building_metadata():
     True
     >>> metadata_df.shape[1] > 10  # at least 10 columns
     True
-    >>> metadata = metadata_df.iloc[0]
-    >>> string_columns = (
-    ...     'county', 'ashrae_iecc_climate_zone', 'foundation_type',
-    ...     'windows_type', 'wall_type', 'wall_material', 'attic_type',
-    ... )
-    >>> all(
-    ...     not isinstance(value, str)
-    ...     for col, value in metadata.items() if col not in string_columns
-    ... )
-    True
     """
     pq = pd.read_parquet(
         BUILDING_METADATA_PARQUET_PATH,

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -803,12 +803,14 @@ class DataGen(tf.keras.utils.Sequence):
         This method should produce a dictionary of numpy arrays (or tensors)
         """
         batch_ids = self.ids[idx*self.batch_size:(idx+1)*self.batch_size]
-        building_inputs = np.empty((self.batch_size, len(self.building_features)), dtype=self.dtype)
+        # for last batch, batch_size might be different from self.batch_size
+        batch_size = batch_ids.shape[0]
+        building_inputs = np.empty((batch_size, len(self.building_features)), dtype=self.dtype)
         # keras convolutions only support NHWC (i.e., channels last)
         # so, time dimension comes first, than features
-        weather_inputs = np.empty((self.batch_size, HOURS_IN_A_YEAR, len(self.weather_features)), dtype=self.dtype)
+        weather_inputs = np.empty((batch_size, HOURS_IN_A_YEAR, len(self.weather_features)), dtype=self.dtype)
         # on larger batches (128), np.float32 is not enough to handle the loss
-        outputs = np.empty((self.batch_size, len(self.consumption_groups), self.output_length), dtype=self.dtype)
+        outputs = np.empty((batch_size, len(self.consumption_groups), self.output_length), dtype=self.dtype)
 
         for i, (building_id, upgrade_id) in enumerate(batch_ids):
             building_features = self.metadata_builder(building_id).copy()

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -526,7 +526,7 @@ def get_state_code_from_county_geoid(county_geoid):
     if state_2num_code not in STATE_2NUM_CODE_TO_2LETTER:
         raise ValueError(
             f"Invalid state code (`{state_2num_code}`) in county geoid: "
-            f"`{county_geoid}`. Values between `00` and `50` expected"
+            f"`{county_geoid}`. Values between `00` and `56` expected"
         )
     return STATE_2NUM_CODE_TO_2LETTER[state_2num_code]
 

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -124,15 +124,17 @@ LUMINOUS_EFFICACY = {
 }
 
 
-def extract_cooling_space_percentage(value):
+def extract_percentage(value):
     """ Extract percentage of space given
 
-    >>> extract_cooling_space_percentage('100% Conditioned')
+    >>> extract_percentage('100% Conditioned')
     1.0
-    >>> extract_cooling_space_percentage('<10% Conditioned')
+    >>> extract_percentage('<10% Conditioned')
     0.1
-    >>> extract_cooling_space_percentage('None')
+    >>> extract_percentage('None')
     0.0
+    >>> extract_percentage('10% Leakage, Uninsulated')
+    0.1
     """
     if value == 'None':
         return 0.0
@@ -416,7 +418,7 @@ def _get_building_metadata():
         heating_efficiency=pq['in.hvac_heating_efficiency'].map(extract_heating_efficiency),
         cooling_setpoint=pq['in.cooling_setpoint'].map(temp70),
         heating_setpoint=pq['in.heating_setpoint'].map(temp70),
-        cooled_space_share=pq['in.hvac_cooling_partial_space_conditioning'].map(extract_cooling_space_percentage),
+        cooled_space_share=pq['in.hvac_cooling_partial_space_conditioning'].map(extract_percentage),
         orientation=pq['in.orientation'].map(ORIENTATION_DEGREES),
         # door area in ResStock is always the same (20), and thus, useless
         window_area=pq['in.window_areas'].map(extract_window_area),

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -1031,6 +1031,18 @@ class DataGen(tf.keras.utils.Sequence):
             for group in self.consumption_groups
         }
 
+    def feature_dtype(self, feature_name):
+        is_string_feature = self.building_features_df[feature_name].dtype == 'O'
+        return tf.string if is_string_feature else self.dtype
+
+    def feature_vocab(self, feature_name):
+        """ Get all possible values for a feature
+
+        This method is used to create encoders for string (categorical/ordinal)
+        features
+        """
+        return self.metadata_builder.all()[feature_name].unique()
+
     def __len__(self):
         # number of batches; last batch might be smaller
         return math.ceil(len(self.ids) / self.batch_size)

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -834,3 +834,12 @@ class DataGen(tf.keras.utils.Sequence):
         }, {
             'outputs': outputs
         }
+
+    def cache_warmup(self, num_threads=None):
+        from multiprocessing.pool import ThreadPool
+        # limit to 50 threads to avoid saturation
+        num_threads = num_threads or min(os.cpu_count()*10, 50)
+        tp = ThreadPool(num_threads)
+        tp.imap_unordered(lambda i: self[i] and None, range(len(self)))
+        tp.close()
+        tp.join()

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -872,7 +872,6 @@ class DataGen(tf.keras.utils.Sequence):
     # to predict real life usage well
     consumption_groups = ('heating', 'cooling',)
     time_granularity = None
-    weather_files_cache: Dict[str, np.array]
     # Building ids only, not combined with upgrades.
     # Not used, for debugging purpose only
     building_ids: np.array
@@ -923,7 +922,6 @@ class DataGen(tf.keras.utils.Sequence):
         self.building_features = list(building_features or self.building_features)
         self.consumption_groups = list(consumption_groups or self.consumption_groups)
         self.time_granularity = time_granularity
-        self.weather_files_cache = {}
         self.batch_size = batch_size
         self.building_ids = np.fromiter(building_ids, int)
         # 1D numpy array of tuples - to support np.random.shuffle and at the

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -425,7 +425,7 @@ def _get_building_metadata():
             extract_heating_efficiency),
         ac_type=pq['in.hvac_cooling_efficiency'].str.split(',').str[0],
         has_ac=(
-            pq['in.hvac_cooling_efficiency'].str.split(',').str[0] == 'None'
+            pq['in.hvac_cooling_efficiency'].str.split(',').str[0] != 'None'
         ).astype(int),
         has_ducts=pq['in.hvac_has_ducts'].map({'Yes': 1, 'No': 0}),
         ducts_insulation=pq['in.ducts'].map(extract_r_value),

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -1161,3 +1161,12 @@ class DataGen(tf.keras.utils.Sequence):
         return features, self.batch_output_features(batch_ids)
 
 
+if __name__ == '__main__':
+    np.random.seed(42)  # 42 is always the answer
+    N = 5
+    get_building_metadata = BuildingMetadataBuilder()
+    building_ids = get_building_metadata.building_ids
+    np.random.shuffle(building_ids)
+    building_ids = building_ids[:N]
+    train_gen = DataGen(building_ids)
+    train_gen[0]

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -416,7 +416,7 @@ def _get_building_metadata():
         heating_efficiency=pq['in.hvac_heating_efficiency'].map(extract_heating_efficiency),
         cooling_setpoint=pq['in.cooling_setpoint'].map(temp70),
         heating_setpoint=pq['in.heating_setpoint'].map(temp70),
-        cooled_spache_share=pq['in.hvac_cooling_partial_space_conditioning'].map(extract_cooling_space_percentage),
+        cooled_space_share=pq['in.hvac_cooling_partial_space_conditioning'].map(extract_cooling_space_percentage),
         orientation=pq['in.orientation'].map(ORIENTATION_DEGREES),
         # door area in ResStock is always the same (20), and thus, useless
         window_area=pq['in.window_areas'].map(extract_window_area),
@@ -453,8 +453,7 @@ class BuildingMetadataBuilder:
 
         'insulation_slab', 'insulation_rim_joist', 'insulation_floor',
         'cooling_setpoint', 'heating_setpoint', 'orientation', 'window_area',
-        'lighting_efficiency', 'cooled_spache_share',
-
+        'lighting_efficiency', 'cooled_space_share',
         # categorical
         'foundation_type', 'windows_type',
     )

--- a/src/model.py
+++ b/src/model.py
@@ -1,7 +1,10 @@
 #! /usr/bin/env python3
+import itertools
+from typing import Dict
 
+import matplotlib.pyplot as plt
 import numpy as np
-import tensorflow as tf
+import pandas as pd
 from tensorflow import keras
 import tensorflow.keras.backend as K
 from tensorflow.keras import layers, models
@@ -9,14 +12,10 @@ from tensorflow.keras import layers, models
 import datagen
 
 
-def create_dataset(batch_size=64, train_test_split=0.8):
+def create_dataset(datagen_params: Dict, train_test_split=0.8):
+
     get_building_metadata = datagen.BuildingMetadataBuilder()
     building_ids = get_building_metadata.building_ids
-    datagen_params = {
-        # 'building_features': ...,
-        'metadata_builder': get_building_metadata,
-        'batch_size': batch_size,
-    }
     np.random.shuffle(building_ids)
     train_buildings, test_buildings = datagen.train_test_split(
         building_ids, left_size=train_test_split)
@@ -31,7 +30,7 @@ def gaussian_activation(x):
     return K.exp(-K.pow(x, 2))
 
 
-def create_model(model_config=None):
+def create_model(layer_params=None):
     """ End to end model architecture definition
 
     Model config should include:
@@ -48,6 +47,7 @@ def create_model(model_config=None):
             - CNN config for weather features
                 - a list of CNN1D layers with number of filters
     """
+    layer_params = layer_params or {}
     train_gen, test_gen = create_dataset()
 
     # Building model
@@ -123,12 +123,86 @@ def create_model(model_config=None):
     return final_model
 
 
+def plot_history(history):
+    plt.plot(history.history['loss'])
+    plt.plot(history.history['val_loss'])
+
+    plt.title('model loss')
+    plt.ylabel('loss')
+    plt.xlabel('epoch')
+    plt.legend(['train', 'val'], loc='upper left')
+    plt.show()
+
+
+def debug_scatterplots(gen, final_model):
+    gt = np.empty((len(gen.ids), len(gen.consumption_groups)))
+    for batch_num in range(len(gen)):
+        _, batch_gt = gen[batch_num]
+        batch_gt = batch_gt['outputs']
+        gt[gen.batch_size * batch_num:gen.batch_size * batch_num + len(batch_gt)] = batch_gt.sum(axis=-1)
+    predictions = final_model.predict(gen)['outputs']
+    groups = {
+        'gt': gt,
+        'pred': predictions
+    }
+    df = pd.DataFrame({
+        group + '_' + consumption : groups[group][:, colnum]
+        for group, (colnum, consumption) in itertools.product(groups, enumerate(gen.consumption_groups))
+    })
+    for consumption_group in gen.consumption_groups:
+        df.plot.scatter(*(group+'_'+consumption_group for group in groups))
+    # consider checking df.corr()
+
+
 def main():
-    final_model = create_model()
-    train_gen, test_gen = create_dataset()
+    layer_params = {
+        'activation': 'leaky_relu',
+        'dtype': np.float32,
+    }
+    final_model = create_model(layer_params)
+    model_architecture_img = keras.utils.plot_model(
+        final_model, to_file="model.png", show_shapes=True, show_dtype=True,
+        rankdir="TB", dpi=200, show_layer_activations=True,
+    )
+
+    get_building_metadata = datagen.BuildingMetadataBuilder()
+    datagen_params = {
+        'metadata_builder': get_building_metadata,
+        'batch_size': 64,
+        # 'consumption_groups': (
+        #   'heating', 'cooling',
+        #   'lighting', 'other',
+        # ),
+        'weather_features': (
+            'temp_air', 'ghi', 'wind_speed',
+            # 'weekend', 'hour',
+            # 'relative_humidity', 'dni', 'diffuse_horizontal_illum',
+            # 'wind_direction',
+        ),
+        'building_features': (
+            'sqft', 'bedrooms', 'stories', 'occupants', 'age2000', 'county',
+            'infiltration_ach50', 'insulation_wall', 'insulation_ceiling_roof',
+            'cooling_efficiency_eer', 'heating_efficiency',
+
+            'cooling_setpoint', 'heating_setpoint',
+            # 'insulation_slab', 'insulation_rim_joist', 'insulation_floor',
+            # 'orientation', 'window_area',
+            # 'lighting_efficiency',
+
+
+            # categorical
+            # 'foundation_type', 'windows_type',
+        ),
+        'dtype': layer_params['dtype'],
+        # 'time_granularity': 'M',
+    }
+
+    train_gen, test_gen = create_dataset(datagen_params)
     history = final_model.fit(
         train_gen, epochs=100, validation_data=test_gen,
         callbacks=[keras.callbacks.EarlyStopping(monitor='loss', patience=5)]
     )
+    plot_history(history)
+    debug_scatterplots(test_gen, final_model)
 
     return history

--- a/src/model.py
+++ b/src/model.py
@@ -30,6 +30,136 @@ def gaussian_activation(x):
     return K.exp(-K.pow(x, 2))
 
 
+def replace_weather_with_embeddings(gen, weather_model):
+    """ Replace weather features in `gen` with embeddings using `weather_model`
+
+    Args:
+        gen: (datagen.DataGen) an instance of a data generator class
+    """
+    # all weather feature dfs are built using the same index.
+    # To be safe, bulletproofing this code
+    sample_weather_feature = gen.weather_features[0]
+    if sample_weather_feature == 'weather_embedding':
+        return  # already transformed
+
+    idx = gen.weather_cache[sample_weather_feature].index
+    weather_embed_input = {
+        weather_feature: gen.weather_cache[weather_feature].loc[idx].values
+        for weather_feature in gen.weather_features
+    }
+    weather_embeddings = pd.DataFrame(weather_model.predict(weather_embed_input), index=idx)
+    gen._weather_features = gen.weather_features
+    gen.weather_features = ['weather_embedding']
+    gen.weather_cache['weather_embedding'] = weather_embeddings
+
+
+def create_building_model(train_gen, layer_params):
+    bmo_inputs_dict = {
+        building_feature: layers.Input(
+            name=building_feature, shape=(1,),
+            dtype=train_gen.feature_dtype(building_feature)
+        )
+        for building_feature in train_gen.building_features
+    }
+
+    # handle categorical, ordinal, etc. features.
+    # Here it is detected by dtype; perhaps explicit feature list and handlers
+    # would be better
+    bmo_inputs = []
+    for feature, layer in bmo_inputs_dict.items():
+        if train_gen.feature_dtype(feature) == tf.string:
+            encoder = layers.StringLookup(
+                name=feature+'_encoder', output_mode='one_hot',
+                dtype=layer_params['dtype']
+            )
+            encoder.adapt(train_gen.feature_vocab(feature))
+            layer = encoder(layer)
+        bmo_inputs.append(layer)
+
+    m = layers.Concatenate(name='concat_layer', dtype=layer_params['dtype'])(bmo_inputs)
+
+    m = layers.Dense(32, name='second_dense', **layer_params)(m)
+    m = layers.Dense(8, name='third_dense', **layer_params)(m)
+    # TODO: consider applying batchnorm
+    # m = layers.BatchNormalization()(m)
+
+    bmo = models.Model(
+        inputs=bmo_inputs_dict, outputs=m, name='building_features_model')
+    return bmo_inputs_dict, bmo
+
+
+def create_weather_model(train_gen, layer_params):
+    weather_inputs_dict = {
+        weather_feature: layers.Input(
+            name=weather_feature, shape=(None, 1,), dtype=layer_params['dtype'])
+        for weather_feature in train_gen.weather_features
+    }
+    weather_inputs = list(weather_inputs_dict.values())
+
+    wm = layers.Concatenate(
+        axis=-1, name='weather_concat_layer', dtype=layer_params['dtype']
+    )(weather_inputs)
+
+    wm = layers.Conv1D(
+        filters=16, # reasonable range is 4..32
+        kernel_size=4,
+        padding='same',
+        data_format='channels_last',
+        name='first_1dconv',
+        **layer_params
+    )(wm)
+    # Performance with only one layer of CNN is abismal.
+    # Use at least one more layer
+    wm = layers.Conv1D(
+        filters=16,
+        kernel_size=4,
+        padding='same',
+        data_format='channels_last',
+        name='last_1dconv',
+        # activation=gaussian_activation,
+        **layer_params
+    )(wm)
+    # sum the time dimension
+    wm = layers.Lambda(
+        lambda x: K.sum(x, axis=1), dtype=layer_params['dtype'])(wm)
+
+    wmo = models.Model(
+        inputs=weather_inputs_dict, outputs=wm, name='weather_features_model')
+    return weather_inputs_dict, wmo
+
+
+def create_combined_model(train_gen, bmo, wmo, layer_params):
+    combined_inputs_dict = {
+        'building_embedding': layers.Input(
+            name='building_embedding', shape=(bmo.output.shape[1],),
+            dtype=layer_params['dtype']),
+        'weather_embedding': layers.Input(
+            name='weather_embedding', shape=(wmo.output.shape[1],),
+            dtype=layer_params['dtype']),
+    }
+    combined_inputs = list(combined_inputs_dict.values())
+    cm = layers.Concatenate(name='combine_features')(combined_inputs)
+
+    cm = layers.Dense(16, **layer_params)(cm)
+    cm = layers.Dense(16, **layer_params)(cm)
+    # cm is a chokepoint representing embedding of a building + climate it is in
+
+    # would be a dict if these outputs were final
+    combined_outputs = {}
+    for consumption_group in train_gen.consumption_groups:
+        io = layers.Dense(8, name=consumption_group+'_entry', **layer_params)(cm)
+        # ... feel free to add more layers
+        io = layers.Dense(8, name=consumption_group+'_mid', **layer_params)(io)
+        # no activation on the output
+        io = layers.Dense(1, name=consumption_group, **layer_params)(io)
+        combined_outputs[consumption_group] = io
+
+    combined_model = models.Model(
+        inputs=combined_inputs_dict, outputs=combined_outputs,
+        name='combined_model')
+    return combined_inputs_dict, combined_model
+
+
 def create_model(layer_params=None):
     """ End to end model architecture definition
 
@@ -51,92 +181,56 @@ def create_model(layer_params=None):
     train_gen, test_gen = create_dataset()
 
     # Building model
-    bmo_inputs_dict = {
-        building_feature: layers.Input(
-            name=building_feature, shape=(1,),
-            dtype=train_gen.feature_dtype(building_feature)
-        )
-        for building_feature in train_gen.building_features
-    }
-    bmo_inputs = []
-    for feature, layer in bmo_inputs_dict.items():
-        # handle categorical, ordinal, etc. features.
-        # Here it is detected by dtype; perhaps explicit feature list and
-        # handlers would be better
-        if train_gen.feature_dtype(feature) == tf.string:
-            encoder = layers.StringLookup(
-                name=feature+'_encoder', output_mode='one_hot',
-                dtype=layer_params['dtype']
-            )
-            encoder.adapt(train_gen.feature_vocab(feature))
-            layer = encoder(layer)
-        bmo_inputs.append(layer)
-
-    bm = layers.Concatenate(name='concat_layer', dtype=layer_params['dtype'])(bmo_inputs)
-    bm = layers.Dense(32, name='second_dense', **layer_params)(bm)
-    bm = layers.Dense(8, name='third_dense', **layer_params)(bm)
-
-    bmo = models.Model(inputs=bmo_inputs_dict, outputs=bm, name='building_features_model')
+    bmo_inputs_dict, bmo = create_building_model(train_gen, layer_params)
 
     # Weather data model
-    weather_inputs_dict = {
-        weather_feature: layers.Input(
-            name=weather_feature, shape=(None, 1,), dtype=layer_params['dtype'])
-        for weather_feature in train_gen.weather_features
-    }
-    weather_inputs = list(weather_inputs_dict.values())
-
-    wm = layers.Concatenate(
-        axis=-1, name='weather_concat_layer', dtype=layer_params['dtype']
-    )(weather_inputs)
-    wm = layers.Conv1D(
-        filters=16,
-        kernel_size=8,
-        padding='same',
-        data_format='channels_last',
-        name='first_1dconv',
-        **layer_params
-    )(wm)
-    wm = layers.Conv1D(
-        filters=8,
-        kernel_size=8,
-        padding='same',
-        data_format='channels_last',
-        name='last_1dconv',
-        **layer_params
-    )(wm)
-
-    # sum the time dimension
-    wm = layers.Lambda(
-        lambda x: K.sum(x, axis=1), dtype=layer_params['dtype'])(wm)
-
-    wmo = models.Model(
-        inputs=weather_inputs_dict, outputs=wm, name='weather_features_model')
+    weather_inputs_dict, wmo = create_weather_model(train_gen, layer_params)
 
     # Combined model and separate towers for output groups
-    cm = layers.Concatenate(name='combine_features')([bmo.output, wmo.output])
-    cm = layers.Dense(16, **layer_params)(cm)
-    cm = layers.Dense(16, **layer_params)(cm)
-    # cm is a chokepoint representing embedding of a building + climate it is in
+    combined_inputs_dict, combined_model = create_combined_model(
+        train_gen, bmo, wmo, layer_params)
 
-    # building a separate tower for each output group
-    final_outputs = {}
-    for consumption_group in train_gen.consumption_groups:
-        io = layers.Dense(8, name=consumption_group+'_entry', **layer_params)(cm)
-        # ... feel free to add more layers
-        io = layers.Dense(8, name=consumption_group+'_mid', **layer_params)(io)
-        # no activation on the output
-        io = layers.Dense(1, name=consumption_group, **layer_params)(io)
-        final_outputs[consumption_group] = io
+    building_embedding = bmo(bmo_inputs_dict)
+    weather_embedding = wmo(weather_inputs_dict)
+    combined_output = combined_model({
+        'building_embedding': building_embedding,
+        'weather_embedding': weather_embedding
+    })
 
     final_model = models.Model(
-        inputs=itertools.ChainMap(bmo.input, wmo.input), outputs=final_outputs)
-
-    final_model.compile(
-        loss=keras.losses.MeanAbsoluteError(),
-        optimizer='adam'
+        inputs=itertools.ChainMap(bmo_inputs_dict, weather_inputs_dict),
+        outputs=combined_output
     )
-    return final_model
+
+    final_model.compile(loss=keras.losses.MeanAbsoluteError(), optimizer='adam')
+    # return final_model
+
+    history = final_model.fit(
+        train_gen, epochs=100, validation_data=test_gen,
+        callbacks=[keras.callbacks.EarlyStopping(monitor='loss', patience=5)]
+    )
+
+    # Experimental: fix weather embeddings and continue training
+    # This leads to about 30x faster epochs, while still making progress in
+    # predictions quality
+    replace_weather_with_embeddings(train_gen, wmo)
+    replace_weather_with_embeddings(test_gen, wmo)
+
+    combined_output2 = combined_model({
+        'building_embedding': building_embedding,
+        'weather_embedding': combined_inputs_dict['weather_embedding']
+    })
+
+    final_model2 = models.Model(inputs=itertools.ChainMap(bmo_inputs_dict, {
+        'weather_embedding': combined_inputs_dict['weather_embedding']
+    }), outputs=combined_output2)
+    final_model2.compile(loss=keras.losses.MeanAbsoluteError(),optimizer='adam')
+
+    history2 = final_model2.fit(
+        train_gen, epochs=200, validation_data=test_gen,
+        callbacks=[keras.callbacks.EarlyStopping(monitor='loss', patience=10)]
+    )
+    return final_model2, wmo
 
 
 def plot_history(history):


### PR DESCRIPTION
The idea behind this refactoring is to enable categorical/ordinal features. Previously, all building features for the batch were stored in a single numpy array, and thus had to have the same dtype. Now, each feature is a separate input for the model, which enables string features to be encoded on the model side.

Another major change is in-memory caching. Previously, batches were formed on demand, getting underlying files from a filesystem cache every time. Now, there is an additional layer of caching in RAM. The reason it works is that building features are represented by a relatively small table (a couple million rows and about a dozen columns), there are only a few thousand weather files, and for output we usually aggregate it to only a few hundred outputs. RAM caching speeds up training by ~2x locally. It should also allow to overcome disk performance bottleneck on DataBricks and enable efficient training on GPU  (but the model storage and serving questions still remain).

Where RAM caching is not going to make it is hourly model (still in making).  My impression is that we won't be able to train hourly model on DataBricks at all. As an alternative, it can be trained locally (including on a manually managed GPU instance) or using an alternative platform, like Vertex AI.