### PR TITLE
Weather embedding gpu join

### DIFF
--- a/src/build_feature_store.py
+++ b/src/build_feature_store.py
@@ -42,6 +42,7 @@ from functools import reduce
 from itertools import chain
 from typing import Dict
 
+from pyspark.ml.feature import StringIndexer
 import pyspark.sql.functions as F
 from databricks.feature_engineering import FeatureEngineeringClient
 from pyspark.sql import DataFrame
@@ -574,6 +575,16 @@ luminous_efficiency_mapping = make_map_type_from_dict(
 
 # COMMAND ----------
 
+# DBTITLE 1,Create StringIndexer to creater a weather_file_city_index column
+# Create the StringIndexer
+indexer = StringIndexer(
+    inputCol="weather_file_city", 
+    outputCol="weather_file_city_index", 
+    stringOrderType="alphabetAsc"
+)
+
+# COMMAND ----------
+
 # DBTITLE 1,Building metadata feature transformation function
 def transform_building_features() -> DataFrame:
     """
@@ -909,6 +920,9 @@ def transform_building_features() -> DataFrame:
             "n_occupants",
             "vintage",
         )
+    )
+    building_metadata_transformed = (
+        indexer.fit(building_metadata_transformed).transform(building_metadata_transformed)
     )
     return building_metadata_transformed
 

--- a/src/build_feature_store.py
+++ b/src/build_feature_store.py
@@ -924,7 +924,7 @@ def transform_building_features() -> DataFrame:
     building_metadata_transformed = (
         indexer
         .fit(building_metadata_transformed).transform(building_metadata_transformed)
-        #.withColumn("weather_file_city_index", F.col("weather_file_city_index").cast("int"))
+        .withColumn("weather_file_city_index", F.col("weather_file_city_index").cast("int"))
     )
     return building_metadata_transformed
 
@@ -1348,15 +1348,11 @@ if spark.catalog.tableExists(table_name):
 else:
     fe.create_table(
         name=table_name,
-        primary_keys=["building_id", "upgrade_id"],
+        primary_keys=["building_id", "upgrade_id", "weather_file_city"],
         df=df,
         schema=df.schema,
         description="building metadata features",
     )
-
-# COMMAND ----------
-
-building_metadata_applicable_upgrades.select('weather_file_city', 'weather_file_city_index').distinct().display()
 
 # COMMAND ----------
 

--- a/src/build_feature_store.py
+++ b/src/build_feature_store.py
@@ -43,7 +43,6 @@ from itertools import chain
 from typing import Dict
 
 import pyspark.sql.functions as F
-from pyspark.sql.functions import row_number
 from databricks.feature_engineering import FeatureEngineeringClient
 from pyspark.sql import DataFrame
 from pyspark.sql.column import Column

--- a/src/build_feature_store.py
+++ b/src/build_feature_store.py
@@ -1269,9 +1269,6 @@ def transform_weather_features() -> DataFrame:
     weather_df = spark.read.table("ml.surrogate_model.weather_data_hourly")
     weather_pkeys = ["weather_file_city"]
 
-    # Define a window specification, partitioning by `weather_file_city` and ordering by it
-    window_spec = Window.orderBy("weather_file_city")
-
     weather_data_arrays = (
         weather_df.groupBy(weather_pkeys).agg(
         *[
@@ -1279,7 +1276,7 @@ def transform_weather_features() -> DataFrame:
             for c in weather_df.columns
             if c not in weather_pkeys + ["datetime_formatted"]
         ]
-    ).withColumn('weather_file_city_index', row_number().over(window_spec))
+    )
     )
     return weather_data_arrays
 

--- a/src/build_feature_store.py
+++ b/src/build_feature_store.py
@@ -922,7 +922,9 @@ def transform_building_features() -> DataFrame:
         )
     )
     building_metadata_transformed = (
-        indexer.fit(building_metadata_transformed).transform(building_metadata_transformed)
+        indexer
+        .fit(building_metadata_transformed).transform(building_metadata_transformed)
+        #.withColumn("weather_file_city_index", F.col("weather_file_city_index").cast("int"))
     )
     return building_metadata_transformed
 
@@ -1351,6 +1353,10 @@ else:
         schema=df.schema,
         description="building metadata features",
     )
+
+# COMMAND ----------
+
+building_metadata_applicable_upgrades.select('weather_file_city', 'weather_file_city_index').distinct().display()
 
 # COMMAND ----------
 

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -353,12 +353,7 @@ class DataGenerator(tf.keras.utils.Sequence):
                     np.array of shape [len(feature_df)] for building model features
                     and shape [len(feature_df), 8760] for weather features}
         """
-        X_train_bm = {col: np.array(feature_df[col]) for col in self.building_features}
-        X_train_weather_lookup = {
-            col: np.array(feature_df[col].values)
-            for col in ['weather_file_city_index']
-        }
-        return {**X_train_bm, **X_train_weather_lookup}
+        return {col: np.array(feature_df[col]) for col in self.building_features + ['weather_file_city_index']}
 
     def __len__(self) -> int:
         """

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -232,7 +232,7 @@ class DataGenerator(tf.keras.utils.Sequence):
     def init_training_set(
         self,
         train_data: DataFrame,
-        exclude_columns: List[str] = ["building_id", "upgrade_id", "weather_file_city"],
+        exclude_columns: List[str] = ["building_id", "upgrade_id"],
     ) -> TrainingSet:
         """
         Initializes the Databricks TrainingSet object contaning targets, building feautres and weather features.
@@ -240,7 +240,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         Parameters:
             - train_data (DataFrame): the training data containing the targets and keys to join to the feature tables.
             - exclude_columns (list of str): columns to be excluded from the output training set.
-                                             Defaults to the join keys: ["building_id", "upgrade_id", "weather_file_city"].
+                                             Defaults to the join keys: ["building_id", "upgrade_id"].
 
         Returns:
         - TrainingSet
@@ -288,7 +288,7 @@ class DataGenerator(tf.keras.utils.Sequence):
 
         return weather_features_table.select(
             "weather_file_city", *self.weather_features
-        ).toPandas()
+        ).toPandas().reset_index().rename(columns={'index': 'weather_file_city_index'})
 
     def feature_dtype(self, feature_name: str) -> Any:
         """
@@ -385,7 +385,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         ]
         # join batch targets and building features to weather file city index
         batch_df = batch_df.merge(
-            self.weather_features_df[['weather_file_city']].reset_index().rename(columns={'index': 'weather_file_city_index'}), on="weather_file_city", how="left"
+            self.weather_features_df[['weather_file_city', 'weather_file_city_index']], on="weather_file_city", how="left"
         )
         # convert from df to dict
         X = self.convert_dataframe_to_dict(feature_df=batch_df)

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -363,7 +363,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         - int: The number of batches.
         """
         return math.ceil(len(self.training_df) / self.batch_size)
-
+    
     def __getitem__(
         self, index: int
     ) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
@@ -382,9 +382,9 @@ class DataGenerator(tf.keras.utils.Sequence):
         batch_df = self.training_df.iloc[
             self.batch_size * index : self.batch_size * (index + 1)
         ]
-        # join batch targets and building features to weather features
+        # join batch targets and building features to weather file city index
         batch_df = batch_df.merge(
-            self.weather_features_df, on="weather_file_city", how="left"
+            self.weather_features_df[['weather_file_city', 'weather_file_city_index']], on="weather_file_city", how="left"
         )
         # convert from df to dict
         X = self.convert_dataframe_to_dict(feature_df=batch_df)

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -133,14 +133,15 @@ class DataGenerator(tf.keras.utils.Sequence):
     ]
 
     weather_features = [
-        "temp_air",
-        # "relative_humidity",
-        "wind_speed",
-        # "wind_direction",
-        "ghi",
-        # "dni",
-        # "diffuse_horizontal_illum",
-        "weekend",
+        # "temp_air",
+        # # "relative_humidity",
+        # "wind_speed",
+        # # "wind_direction",
+        # "ghi",
+        # # "dni",
+        # # "diffuse_horizontal_illum",
+        # "weekend",
+        "weather_file_city_index"
     ]
 
     consumption_group_dict = {

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -35,6 +35,7 @@ class DataGenerator(tf.keras.utils.Sequence):
     - training_set (TrainingSet): Databricks TrainingSet object contaning targets, building feautres and weather features.
     - training_df (pd.DataFrame): Dataframe of building features and targets of shape [N, P_b + M]. Does not include weather features.
     - weather_features_df (pd.DataFrame): Dataframe of building features of shape [N, P_w] where each column contains a 8760-length vector.
+    - weather_features_matrix (numpy.ndarray): A 3D matrix of shape (number of weather file cities, number of weather features, and number of hours in a year) representing weather data for various cities over the course of a year. 
     - building_feature_vocab_dict (dict): Dict of format {feature_name : {"dtype": feature_dtype, "vocab": np.array
                                         of all possible features if string feature else empty}}.
     - fe (databricks.feature_engineering.client.FeatureEngineeringClient: client for interacting with the

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -210,7 +210,7 @@ class DataGenerator(tf.keras.utils.Sequence):
             FeatureLookup(
                 table_name=self.building_feature_table_name,
                 feature_names=self.building_features + ['weather_file_city_index'],
-                lookup_key=["building_id", "upgrade_id"],
+                lookup_key=["building_id", "upgrade_id", "weather_file_city"],
             ),
         ]
 

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -133,15 +133,14 @@ class DataGenerator(tf.keras.utils.Sequence):
     ]
 
     weather_features = [
-        # "temp_air",
-        # # "relative_humidity",
-        # "wind_speed",
-        # # "wind_direction",
-        # "ghi",
-        # # "dni",
-        # # "diffuse_horizontal_illum",
-        # "weekend",
-        "weather_file_city_index"
+        "temp_air",
+        # "relative_humidity",
+        "wind_speed",
+        # "wind_direction",
+        "ghi",
+        # "dni",
+        # "diffuse_horizontal_illum",
+        "weekend",
     ]
 
     consumption_group_dict = {
@@ -195,6 +194,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         )
 
         self.weather_features_df = self.init_weather_features()
+        self.weather_features_matrix = self.weather_features_df[self.weather_features].to_numpy()
         self.building_feature_vocab_dict = self.init_building_feature_vocab_dict()
 
         self.on_epoch_end()
@@ -350,11 +350,11 @@ class DataGenerator(tf.keras.utils.Sequence):
                     and shape [len(feature_df), 8760] for weather features}
         """
         X_train_bm = {col: np.array(feature_df[col]) for col in self.building_features}
-        X_train_weather = {
-            col: np.array(np.vstack(feature_df[col].values))
-            for col in self.weather_features
+        X_train_weather_lookup = {
+            col: np.array(feature_df[col].values)
+            for col in ['weather_file_city_index']
         }
-        return {**X_train_bm, **X_train_weather}
+        return {**X_train_bm, **X_train_weather_lookup}
 
     def __len__(self) -> int:
         """
@@ -385,7 +385,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         ]
         # join batch targets and building features to weather file city index
         batch_df = batch_df.merge(
-            self.weather_features_df[['weather_file_city', 'weather_file_city_index']], on="weather_file_city", how="left"
+            self.weather_features_df[['weather_file_city']].reset_index().rename(columns={'index': 'weather_file_city_index'}), on="weather_file_city", how="left"
         )
         # convert from df to dict
         X = self.convert_dataframe_to_dict(feature_df=batch_df)

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -196,7 +196,9 @@ class DataGenerator(tf.keras.utils.Sequence):
         )
 
         self.weather_features_df = self.init_weather_features()
-        self.weather_features_matrix = self.weather_features_df.sort_values(by = 'weather_file_city_index')[self.weather_features].to_numpy()
+        self.weather_features_matrix = np.stack(
+            self.weather_features_df.sort_values(by = 'weather_file_city_index')[self.weather_features].apply(lambda row: np.stack(row), axis=1).values
+            )
         self.building_feature_vocab_dict = self.init_building_feature_vocab_dict()
 
         self.on_epoch_end()

--- a/src/datagen.py
+++ b/src/datagen.py
@@ -196,7 +196,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         )
 
         self.weather_features_df = self.init_weather_features()
-        self.weather_features_matrix = self.weather_features_df.sort_values(by = 'weather_file_city')[self.weather_features].to_numpy()
+        self.weather_features_matrix = self.weather_features_df.sort_values(by = 'weather_file_city_index')[self.weather_features].to_numpy()
         self.building_feature_vocab_dict = self.init_building_feature_vocab_dict()
 
         self.on_epoch_end()
@@ -289,7 +289,7 @@ class DataGenerator(tf.keras.utils.Sequence):
         )
 
         return weather_features_table.select(
-            "weather_file_city", *self.weather_features
+            "weather_file_city_index", *self.weather_features
         ).toPandas()
 
     def feature_dtype(self, feature_name: str) -> Any:

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -288,6 +288,10 @@ with mlflow.start_run() as run:
 
 # COMMAND ----------
 
+final_model.summary()
+
+# COMMAND ----------
+
 # MAGIC %md ## Evaluate Model
 
 # COMMAND ----------
@@ -312,11 +316,6 @@ model_loaded = mlflow.pyfunc.load_model(model_uri=sm.get_model_uri(run_id=run_id
 test_gen = DataGenerator(train_data=test_data.limit(10))
 # load input data table as a Spark DataFrame
 input_data = test_gen.training_set.load_df().toPandas()
-# Merge to weather file city index 
-input_data_weather_file_city_index = (
-    input_data
-    .merge(test_gen.weather_features_df[['weather_file_city', 'weather_file_city_index']], on = 'weather_file_city', how = 'left')
-)
 # run prediction and output a N x M matrix of predictions where N is the number of rows in the input data table and M is the number of target columns
 print(model_loaded.predict(input_data_weather_file_city_index))
 

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -103,19 +103,6 @@ val_gen = DataGenerator(train_data=val_data)
 
 # COMMAND ----------
 
-train_gen.training_df[train_gen.training_df['weather_file_city_index'].isna()]['weather_file_city'].unique()
-
-# COMMAND ----------
-
-len(train_gen.training_df[train_gen.training_df['weather_file_city_index'].isna()]['weather_file_city'].unique())
-
-# COMMAND ----------
-
-train_gen.training_df['weather_file_city_index'] = train_gen.training_df['weather_file_city_index'].astype(int)
-val_gen.training_df['weather_file_city_index'] = val_gen.training_df['weather_file_city_index'].astype(int)
-
-# COMMAND ----------
-
 # DBTITLE 1,Inspect data gen output for one batch
 if DEBUG:
     print("FEATURES:")
@@ -326,10 +313,14 @@ test_gen = DataGenerator(train_data=test_data.limit(10))
 # load input data table as a Spark DataFrame
 input_data = test_gen.training_set.load_df().toPandas()
 # run prediction and output a N x M matrix of predictions where N is the number of rows in the input data table and M is the number of target columns
-print(model_loaded.predict(input_data_weather_file_city_index))
+print(model_loaded.predict(input_data))
 
 # COMMAND ----------
 
 # DBTITLE 1,Pass Run ID to next notebook if running in job
 if not DEBUG:
     dbutils.jobs.taskValues.set(key="run_id", value=run_id)
+
+# COMMAND ----------
+
+

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -211,12 +211,7 @@ class SurrogateModelingWrapper(mlflow.pyfunc.PythonModel):
         - The preprocessed feature data in format {feature_name (str) :
                 np.array of shape [N] for building model features and shape [N,8760] for weather features}
         """
-        X_train_bm = {col: np.array(feature_df[col]) for col in self.building_features}
-        X_train_weather = {
-            col: np.array(np.vstack(feature_df[col].values))
-            for col in ['weather_file_city_index']
-        }
-        return {**X_train_bm, **X_train_weather}
+        return {col: np.array(feature_df[col]) for col in self.building_features + ['weather_file_city_index']}
 
 # COMMAND ----------
 

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -103,6 +103,19 @@ val_gen = DataGenerator(train_data=val_data)
 
 # COMMAND ----------
 
+train_gen.training_df[train_gen.training_df['weather_file_city_index'].isna()]['weather_file_city'].unique()
+
+# COMMAND ----------
+
+len(train_gen.training_df[train_gen.training_df['weather_file_city_index'].isna()]['weather_file_city'].unique())
+
+# COMMAND ----------
+
+train_gen.training_df['weather_file_city_index'] = train_gen.training_df['weather_file_city_index'].astype(int)
+val_gen.training_df['weather_file_city_index'] = val_gen.training_df['weather_file_city_index'].astype(int)
+
+# COMMAND ----------
+
 # DBTITLE 1,Inspect data gen output for one batch
 if DEBUG:
     print("FEATURES:")
@@ -285,10 +298,6 @@ with mlflow.start_run() as run:
     )
     # skip registering model for now..
     # mlflow.register_model(f"runs:/{run_id}/{sm.artifact_path}", str(sm))
-
-# COMMAND ----------
-
-final_model.summary()
 
 # COMMAND ----------
 

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -214,7 +214,7 @@ class SurrogateModelingWrapper(mlflow.pyfunc.PythonModel):
         X_train_bm = {col: np.array(feature_df[col]) for col in self.building_features}
         X_train_weather = {
             col: np.array(np.vstack(feature_df[col].values))
-            for col in self.weather_features
+            for col in ['weather_file_city_index']
         }
         return {**X_train_bm, **X_train_weather}
 
@@ -312,8 +312,13 @@ model_loaded = mlflow.pyfunc.load_model(model_uri=sm.get_model_uri(run_id=run_id
 test_gen = DataGenerator(train_data=test_data.limit(10))
 # load input data table as a Spark DataFrame
 input_data = test_gen.training_set.load_df().toPandas()
+# Merge to weather file city index 
+input_data_weather_file_city_index = (
+    input_data
+    .merge(test_gen.weather_features_df[['weather_file_city', 'weather_file_city_index']], on = 'weather_file_city', how = 'left')
+)
 # run prediction and output a N x M matrix of predictions where N is the number of rows in the input data table and M is the number of target columns
-print(model_loaded.predict(input_data))
+print(model_loaded.predict(input_data_weather_file_city_index))
 
 # COMMAND ----------
 

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -128,6 +128,9 @@ class SurrogateModel:
             inputs=bmo_inputs_dict, outputs=bm, name="building_features_model"
         )
 
+        # Weather look up here
+        
+
         # Weather data model
         weather_inputs_dict = {
             weather_feature: layers.Input(

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -10,7 +10,7 @@ from pyspark.sql.types import ArrayType, DoubleType
 from tensorflow import keras
 from tensorflow.keras import layers, models
 
-from src.databricks.datagen import DataGenerator
+from src.datagen import DataGenerator
 
 
 class SurrogateModel:

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -132,9 +132,7 @@ class SurrogateModel:
         # Weather data model
 
         # Extract number of cities and hours from the weather data for dimensions of embedding layers
-        num_cities = len(train_gen.weather_features_matrix)
-        num_hours = len(train_gen.weather_features_matrix[0][0])
-        num_features = len(train_gen.weather_features_matrix[0])
+        num_cities, num_features, num_hours = train_gen.weather_features_matrix.shape
 
         # Input for the weather_file_city_index (lookup key)
         weather_file_city_index_input = layers.Input(shape=(1,), dtype='int32', name='weather_file_city_index')

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -148,7 +148,7 @@ class SurrogateModel:
                     name=f'{feature_name}_embedding'
                 )(weather_file_city_index_input)
             )
-            for i, feature_name in zip(range(len(train_gen.weather_features)), train_gen.weather_features)
+            for i, feature_name in enumerate(train_gen.weather_features)
         ]
 
         # Concatenate the embeddings for all weather features along the feature axis

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -148,7 +148,7 @@ class SurrogateModel:
         wm = layers.Reshape((num_hours, num_features))(weather_embedding_layer)
 
         # Proceed with batch normalization and convolutions
-        #wm = layers.BatchNormalization(name="init_conv_batchnorm")(wm)
+        wm = layers.BatchNormalization(name="init_conv_batchnorm")(wm)
         wm = conv_batchnorm_relu(wm, filters=16, kernel_size=8, name = "first")
         wm = conv_batchnorm_relu(wm, filters=8, kernel_size=8, name = "second")
 

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -148,7 +148,7 @@ class SurrogateModel:
         wm = layers.Reshape((num_hours, num_features))(weather_embedding_layer)
 
         # Proceed with batch normalization and convolutions
-        wm = layers.BatchNormalization(name="init_conv_batchnorm")(wm)
+        #wm = layers.BatchNormalization(name="init_conv_batchnorm")(wm)
         wm = conv_batchnorm_relu(wm, filters=16, kernel_size=8, name = "first")
         wm = conv_batchnorm_relu(wm, filters=8, kernel_size=8, name = "second")
 

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -145,7 +145,10 @@ class SurrogateModel:
             trainable=False, name='weather_embedding')(weather_file_city_index_input)
         
         # Reshape weather embedding layer
-        wm = layers.Reshape((num_hours, num_features))(weather_embedding_layer)
+        wm = layers.Reshape((num_features, num_hours))(weather_embedding_layer)
+
+        # Apply transpose using a Lambda layer
+        wm = layers.Lambda(lambda x: tf.transpose(x, perm=[0,2,1]))(wm)
 
         # Proceed with batch normalization and convolutions
         wm = layers.BatchNormalization(name="init_conv_batchnorm")(wm)

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -110,7 +110,8 @@ class SurrogateModel:
                     output_mode="one_hot",
                     dtype=layer_params["dtype"],
                 )
-                encoder.adapt(train_gen.building_feature_vocab_dict[feature]["vocab"])
+                vocab_tensor = tf.convert_to_tensor(train_gen.building_feature_vocab_dict[feature]["vocab"])
+                encoder.adapt(vocab_tensor)
                 layer = encoder(layer)
             bmo_inputs.append(layer)
 


### PR DESCRIPTION
This code removes the weather features from the batches of training data and instead adds in an index corresponding to a weather file city. The weather features themselves are then joined via an embedding layer to the training data based on the index, and the weather data proceeds to the convolutional neural network. 

Hard for me to test whether this had the desired effect of reducing training time without running the full training pipeline. I was also not able to test training with GPUs. Perhaps @vengroff has a way? Also, question probably for @mikivee , is the `src/model_training.py` the same notebook used in the job that trains the model? The results after only 2 epochs and based on only 1000 rows of training data yielded some nonsensical results when predicting, hopefully that is by design and the non-job version of the notebook is just used to test whether the full training pipeline works. 