### PR TITLE
Update optimizer path

### DIFF
--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -210,6 +210,8 @@ class SurrogateModel:
 
         final_model.compile(
             loss=masked_mae,
+            # Allows for deserialization on Mac w M1 chip
+            # https://github.com/keras-team/tf-keras/issues/46#issuecomment-1740702701
             optimizer=tf.keras.optimizers.Adam(),
             # metrics=[mape],
         )

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -210,7 +210,7 @@ class SurrogateModel:
 
         final_model.compile(
             loss=masked_mae,
-            optimizer=tf.keras.optimizers.Adam()
+            optimizer=tf.keras.optimizers.Adam(),
             # metrics=[mape],
         )
         return final_model

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -210,7 +210,7 @@ class SurrogateModel:
 
         final_model.compile(
             loss=masked_mae,
-            optimizer="adam",
+            optimizer=tf.keras.optimizers.Adam()
             # metrics=[mape],
         )
         return final_model


### PR DESCRIPTION
Tiny modification to the path to the Adam optimizer which fixed the issue of deserializing a tf==2.14.1 model on a mac with an M1 chip. This is needed to make [this PR](https://github.com/rewiringamerica/dohyo/pull/29) work, which is currently running inference with a test model using this new optimizer path. I will kick off a full retraining run now with this fix. 

 Issue and solution described [here](https://github.com/keras-team/tf-keras/issues/46#issuecomment-1740702701). 