### PR TITLE
Fix upgrade feature bugs

### DIFF
--- a/src/datagen.py
+++ b/src/datagen.py
@@ -131,6 +131,8 @@ class DataGenerator(tf.keras.utils.Sequence):
         "neighbor_distance_ft",
         "n_occupants",
         "vintage",
+        "has_heat_pump_dryer",
+        "has_induction_range",
         # fuel indicators -- these must be present for post-processing to work!!
         "has_methane_gas_appliance",
         "has_fuel_oil_appliance",

--- a/src/feature_utils.py
+++ b/src/feature_utils.py
@@ -1038,17 +1038,18 @@ def apply_upgrades(baseline_building_features: DataFrame, upgrade_id: int) -> Da
         )
     if upgrade_id in [6, 9]:
         upgrade_building_features = (
-            upgrade_building_features
-                .withColumn("water_heater_fuel", F.lit("Electricity"))
-                .withColumn("water_heater_efficiency",
-                    F.when(  # electric tankless don't get upgraded due to likely size constraints
-                        F.col("water_heater_efficiency") == "Electric Tankless",
-                        F.col("water_heater_efficiency"),
-                    )
-                    .when(F.col("n_bedrooms") <= 3, F.lit("Electric Heat Pump, 50 gal, 3.45 UEF"))
-                    .when(F.col("n_bedrooms") == 4, F.lit("Electric Heat Pump, 66 gal, 3.35 UEF"))
-                    .otherwise(F.lit("Electric Heat Pump, 80 gal, 3.45 UEF")))
-                .transform(add_water_heater_features)
+            upgrade_building_features.withColumn("water_heater_fuel", F.lit("Electricity"))
+            .withColumn(
+                "water_heater_efficiency",
+                F.when(  # electric tankless don't get upgraded due to likely size constraints
+                    F.col("water_heater_efficiency") == "Electric Tankless",
+                    F.col("water_heater_efficiency"),
+                )
+                .when(F.col("n_bedrooms") <= 3, F.lit("Electric Heat Pump, 50 gal, 3.45 UEF"))
+                .when(F.col("n_bedrooms") == 4, F.lit("Electric Heat Pump, 66 gal, 3.35 UEF"))
+                .otherwise(F.lit("Electric Heat Pump, 80 gal, 3.45 UEF")),
+            )
+            .transform(add_water_heater_features)
         )
 
     if upgrade_id in [8.1, 9]:

--- a/src/feature_utils.py
+++ b/src/feature_utils.py
@@ -1037,16 +1037,19 @@ def apply_upgrades(baseline_building_features: DataFrame, upgrade_id: int) -> Da
             .withColumn("heating_setpoint_offset_magnitude_degrees_f", F.lit(0.0))
         )
     if upgrade_id in [6, 9]:
-        upgrade_building_features = upgrade_building_features.withColumn(
-            "water_heater_efficiency",
-            F.when(  # electric tankless don't get upgraded due to likely size constraints
-                F.col("water_heater_efficiency") == "Electric Tankless",
-                F.col("water_heater_efficiency"),
-            )
-            .when(F.col("n_bedrooms") <= 3, F.lit("Electric Heat Pump, 50 gal, 3.45 UEF"))
-            .when(F.col("n_bedrooms") == 4, F.lit("Electric Heat Pump, 66 gal, 3.35 UEF"))
-            .otherwise(F.lit("Electric Heat Pump, 80 gal, 3.45 UEF")),
-        ).transform(add_water_heater_features)
+        upgrade_building_features = (
+            upgrade_building_features
+                .withColumn("water_heater_fuel", F.lit("Electricity"))
+                .withColumn("water_heater_efficiency",
+                    F.when(  # electric tankless don't get upgraded due to likely size constraints
+                        F.col("water_heater_efficiency") == "Electric Tankless",
+                        F.col("water_heater_efficiency"),
+                    )
+                    .when(F.col("n_bedrooms") <= 3, F.lit("Electric Heat Pump, 50 gal, 3.45 UEF"))
+                    .when(F.col("n_bedrooms") == 4, F.lit("Electric Heat Pump, 66 gal, 3.35 UEF"))
+                    .otherwise(F.lit("Electric Heat Pump, 80 gal, 3.45 UEF")))
+                .transform(add_water_heater_features)
+        )
 
     if upgrade_id in [8.1, 9]:
         upgrade_building_features = upgrade_building_features.withColumn(

--- a/src/surrogate_model.py
+++ b/src/surrogate_model.py
@@ -304,8 +304,8 @@ class SurrogateModel:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Save to temporary directory
             local_path = os.path.join(temp_dir, fname)
-            keras_model.save(local_path) 
-            
+            keras_model.save(local_path)
+
             # Copy to GCP
             gcp_path = os.path.join(gcp_model_dir, fname)
             with gfile.GFile(local_path, "rb") as f_local:


### PR DESCRIPTION
Fixing a few bugs related to upgrade features and retraining (see [job run](https://4617764665359845.5.gcp.databricks.com/jobs/1097926823028440?o=4617764665359845)). The downstream changes in the Dohyo Repo are made in [this PR](https://github.com/rewiringamerica/dohyo/pull/92). 

### Results:

Results described [here](https://www.notion.so/Building-towards-an-MVP-9cb748ec5ef647fba50a302fa7f152ca?pvs=21) and the direct effect of the bugfix is show in the table below, where the Median APE is for savings for all upgrades except for baseline (upgrade 0), for which absolute consumption is shown. As expected, the improvement was fairly large for upgrades 6 and 9 which were directly effected, but the error decreased for all other upgrades as well because the incorrect feature coding misleading signals for all training data. 

| Upgrade | Median APE (before) | Median APE (after) | Difference |
| --- | --- | --- | --- |
| 0 | 5.2 | 4.4 | -0.8 |
| 1 | 16.5 | 14.5 | -2.0 |
| 11.05 | 12.2 | 10.7 | -1.5 |
| 13.01 | 15 | 11.7 | -3.3 |
| 3 | 13.9 | 11.9 | -2.0 |
| 4 | 11 | 8.9 | -2.1 |
| 6 | 25.8 | 23.1 | -2.7 |
| 9 | 9.8 | 6.5 | -3.3 |

[Notion Ticket:](https://www.notion.so/rewiringamerica/Fix-sumo-upgrade-feature-bugs-14b4c9af1a1c80a0bff4ef0878d97eff?pvs=4) . 
