### PR TITLE
Use designated test service account when running tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         token_format: 'access_token'
         project_id: 'cube-machine-learning'
-        service_account: 'datascience-dev@cube-machine-learning.iam.gserviceaccount.com'
+        service_account: 'github-tests@cube-machine-learning.iam.gserviceaccount.com'
         workload_identity_provider: 'projects/777182164725/locations/global/workloadIdentityPools/github/providers/ra-github-repo'
 
     # We download a lot of dependencies. So free up some space


### PR DESCRIPTION
# Overview
When running tests on GitHub, use the new designated service account instead of the generic datascience-dev account that has broader permissions.

## Issue Ticket
[Ticket](https://rewiringamerica.atlassian.net/browse/RAT-785)

## Change Type
cleanup

## Implementation Notes
<!-- Add relevant context: ex. dependency updates/additions, design notes, or Figma links. -->

## Test Plan
[Successful workflow run](https://github.com/rewiringamerica/surrogate_modeling/actions/runs/17984183201/job/51157999848)
